### PR TITLE
Use importlib_metadata to get version

### DIFF
--- a/src/oil_reservoir_synthesizer/__init__.py
+++ b/src/oil_reservoir_synthesizer/__init__.py
@@ -2,17 +2,13 @@
 This package generates synthetic oil simulator data based
 on perlin noise. See :py:class:`OilSimulator`.
 """
-from pkg_resources import DistributionNotFound, get_distribution
-
+from importlib.metadata import version
 from ._oil_simulator import OilSimulator
 
 __author__ = """Equinor"""
 __email__ = "fg_sib-scout@equinor.com"
 
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    __version__ = "0.0.0"
+__version__ = version(__name__)
 
 __all__ = [
     "OilSimulator",


### PR DESCRIPTION
Remove use of deprecated `pkg_resources` (removed/not installed in Python 3.12) 