### PR TITLE
Use all ruff rules, but with exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,18 @@ src = ["src"]
 
 [tool.ruff.lint]
 select = [
-  "W",   # pycodestyle
-  "I",   # isort
-  "B",   # flake-8-bugbear
-  "SIM", # flake-8-simplify
-  "F",   # pyflakes
-  "PL",  # pylint
-  "UP",  # pyupgrade
+  "ALL"
+]
+ignore = [
+    "ANN",
+    "COM",
+    "D",
+    "EM",
+    "N",
+    "RET",
+    "RUF",
+    "S",
+    "TRY",
 ]
 
 [tool.pylint]


### PR DESCRIPTION
The exception list is shorter compared to explicitly activating all rulesets that are currently passing.